### PR TITLE
Rebase on sync

### DIFF
--- a/.github/workflows/branches_sync.yml
+++ b/.github/workflows/branches_sync.yml
@@ -28,5 +28,5 @@ jobs:
           git fetch origin
           git checkout feld-m-ragkb-main
           git pull
-          git merge origin/main
+          git rebase origin/main
           git push origin feld-m-ragkb-main


### PR DESCRIPTION
On sync of `main` and `feld-m-main-ragkb` branches rebase instead of merge. This way commits making a difference between in `feld-m-main-ragkb` are on top