### PR TITLE
Initialize app before the first user

### DIFF
--- a/src/augment.py
+++ b/src/augment.py
@@ -30,6 +30,11 @@ def get_cached_initializer() -> AugmentationInitializer:
     return AugmentationInitializer()
 
 
+# This is a workaround to initialize the service before the first user entry.
+# Thanks to that the first user won't need to wait long for the app to load.
+get_cached_initializer()
+
+
 @cl.data_layer
 def get_data_layer() -> ChainlitService:
     """


### PR DESCRIPTION
Workaround to initialize the app at startup. This way, the first user doesn't have to wait long for the service to load.